### PR TITLE
Proper [social_class] plurality handling

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -109,7 +109,15 @@
 
 	if(social_class)
 		H.social_class = social_class
-		to_chat(H, "Your social class is <span class='danger'>[H.social_class]</span>, a <span class='danger'>[H.get_social_class_level()]</span> class.")
+		var/class_suffix = ""
+
+		if(social_class == SOCIAL_CLASS_COM || social_class == SOCIAL_CLASS_MED)
+			class_suffix = "n"
+		if(social_class == SOCIAL_CLASS_AC)
+			to_chat(H, "You are an <span class='danger'>anti-citizen</span>, a" + class_suffix + " <span class='danger'>[H.get_social_class_level()]</span> class.")
+		else
+			to_chat(H, "You are a <span class='danger'>[H.social_class]</span>, a" + class_suffix + " <span class='danger'>[H.get_social_class_level()]</span> class.")
+			class_suffix = ""
 
 /datum/job/proc/get_outfit(var/mob/living/carbon/human/H, var/alt_title, var/datum/mil_branch/branch, var/datum/mil_rank/grade)
 	if(alt_title && alt_titles)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -58,8 +58,18 @@
 	msg += "<br>"
 
 	if(social_class)
-		msg += "They are a <span class='danger'>[social_class]</span>, a <span class='danger'>[src.get_social_class_level()]</span> social class."
+		var/class_level = src.get_social_class_level()
+		var/class_suffix = ""
+
+		if(social_class == SOCIAL_CLASS_COM || social_class == SOCIAL_CLASS_MED)
+			class_suffix = "n"
+		if(social_class == SOCIAL_CLASS_AC)
+			msg += "They are an <span class='danger'>anti-citizen</span>, a" + class_suffix + " <span class='danger'>" + class_level + "</span> social class.<br>"
+		else
+			msg += "They are a <span class='danger'>[social_class]</span>, a" + class_suffix + " <span class='danger'>" + class_level + "</span> social class.<br>"
+			class_suffix = ""
 		msg += "<br>"
+
 
 	//uniform
 	if(w_uniform && !skipjumpsuit)


### PR DESCRIPTION


## About the Pull Request
Adds proper plurality to social classes.
<!-- Describe the Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Good grammar, good plurality.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Did you test it?
Yes, even changing social_classes works as it sets the suffix to "" each time.
<!--
Please describe if you ran local tests to ensure compilation. If that is not the case, please make it abundantly clear so a maintainer knows they need to run local checks.
Note that this can include own balancing/gameplay tests, but does not need to.
-->

## Authorship
AnonHault
<!--
Please note down any individuals or otherwise inspirations/sources you have for this code if it is ported or adapted.
We recommend using the git blame.
-->

## Changelog

:cl:
:tweak: Added proper plurality checks to social classes.
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
